### PR TITLE
Add autoFocus to <select>

### DIFF
--- a/src/dropdown.js
+++ b/src/dropdown.js
@@ -12,7 +12,7 @@ const dropdown = ({
     const edit = ({ target: { value } }) => onValue(value); // eslint-disable-line max-len, no-shadow, react/prop-types
 
     return (
-      <select onBlur={edit} onChange={edit} value={value} {...props}>
+      <select onBlur={edit} onChange={edit} value={value} autoFocus {...props}>
         {options.map((option, i) =>
           <option key={i} value={option[fields.value]}>
             {option[fields.name]}


### PR DESCRIPTION
onBlur usually do not fired because element do not receive focus after starting editing, demo:
https://reactabular.js.org/#/examples/all-features

![image](https://cloud.githubusercontent.com/assets/640669/22120271/232eabce-de90-11e6-9b9b-87f629cc34e1.png)
