### PR TITLE
Fix Firefox issue with onBlur

### DIFF
--- a/__tests__/input-test.js
+++ b/__tests__/input-test.js
@@ -44,6 +44,37 @@ describe('edit.input', function () {
     expect(changedValue).toEqual(true);
   });
 
+  it('triggers onValue onBlur with firefox onClick issue', function () {
+    let changedValue = false;
+    const Input = input();
+    const result = TestUtils.renderIntoDocument(
+      <Wrapper>
+        <Input
+          value="name"
+          onValue={() => {
+            changedValue = true;
+          }}
+        />
+      </Wrapper>
+    );
+
+    const renderedInput = TestUtils.findRenderedDOMComponentWithTag(result, 'input');
+
+    renderedInput.value = 'foobar';
+
+    const nativeEvent = {
+      nativeEvent: {
+        explicitOriginalTarget: renderedInput,
+        originalTarget: renderedInput,
+        type: 'blur'
+      }
+    };
+
+    TestUtils.Simulate.blur(renderedInput, nativeEvent);
+
+    expect(changedValue).toEqual(false);
+  });
+
   it('triggers onValue onEnter', function () {
     let changedValue = false;
     const Input = input();

--- a/src/input.js
+++ b/src/input.js
@@ -9,7 +9,14 @@ const input = ({ props } = {}) => {
         onValue(parseValue(value));
       }
     };
-    const onBlur = ({ target: { value } }) => { // eslint-disable-line react/prop-types
+    const onBlur = (event) => { // eslint-disable-line react/prop-types
+      const { target: { value } } = event;
+
+      if (event.nativeEvent.explicitOriginalTarget &&
+        event.nativeEvent.explicitOriginalTarget === event.nativeEvent.originalTarget) {
+        return;
+      }
+
       onValue(parseValue(value));
     };
     const parseValue = v => (value === parseFloat(value) ? parseFloat(v) : v);


### PR DESCRIPTION
I found an issue on Firefox. 

onBlur event is triggered instantly after onClick event for basic input editor.
The issue is better described here: https://tirdadc.github.io/blog/2015/06/11/react-dot-js-firefox-issue-with-onblur/

My React version is: 15.6.1
